### PR TITLE
Interactive mode, save flag and code refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ and you don't need to provide any input.
 You will be able to save the resulting heatmap in any location on your computer just with --save flag:
 
 ```bash
-npx @jointly/spyone --repo-url=<repo-url> --days-to-cover=30 --branch-name=main --output-format=json --save
+npx @jointly/spyone --repoUrl=<repo-url> --days=30 --branch=main --output=json --save
 ```
 
 ### Parameters
 
-- `repo-url`: the URL of the GitHub repository to extract statistics from. This can be either an https or ssh URL.
-- `days-to-cover`: the number of days before today to consider when extracting data from commits. We suggest 30 for highly updated projects and 90 days for common day-to-day work projects.
-- `branch-name` (optional): the name of the branch to consider. Defaults to `main`.
-- `output-format` (optional): Accepts {html|json}. Defaults to `json`.
+- `repoUrl`: the URL of the GitHub repository to extract statistics from. This can be either an https or ssh URL.
+- `days`: the number of days before today to consider when extracting data from commits. We suggest 30 for highly updated projects and 90 days for common day-to-day work projects.
+- `branch` (optional): the name of the branch to consider. Defaults to `main`.
+- `output` (optional): Accepts {html|json}. Defaults to `json`.
 - `save` (optional): If provided, the resulting heatmap will be saved in a file in the current directory or in the directory specified inside the `save` parameter.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,24 @@ This script downloads any Git repository and extracts statistics from its commit
 To use it, run the following command:
 
 ```bash
-npx @jointly/spyone <repo-url> <days-to-cover> <branch-name> <output-format>
+npx @jointly/spyone
 ```
 
-The JSON output opens in your default browser.
+You will be prompted to enter the URL of the repository you want to analyze, the number of days to consider when extracting data from commits, the name of the branch to consider and the output format.
+
+You can provide all the parameters in the command line, like this:
+
+```bash
+npx @jointly/spyone --repo-url=<repo-url> --days-to-cover=30 --branch-name=main --output-format=json
+```
+
+and you don't need to provide any input.
+
+You will be able to save the resulting heatmap in any location on your computer just with --save flag:
+
+```bash
+npx @jointly/spyone --repo-url=<repo-url> --days-to-cover=30 --branch-name=main --output-format=json --save
+```
 
 ### Parameters
 
@@ -23,3 +37,4 @@ The JSON output opens in your default browser.
 - `days-to-cover`: the number of days before today to consider when extracting data from commits. We suggest 30 for highly updated projects and 90 days for common day-to-day work projects.
 - `branch-name` (optional): the name of the branch to consider. Defaults to `main`.
 - `output-format` (optional): Accepts {html|json}. Defaults to `json`.
+- `save` (optional): If provided, the resulting heatmap will be saved in a file in the current directory or in the directory specified inside the `save` parameter.

--- a/help.mjs
+++ b/help.mjs
@@ -1,0 +1,22 @@
+export const help = `
+Usage: npx @jointly/spyone [options]
+
+If no options are provided, the tool will run in interactive mode.
+
+Options:
+
+    The repo url to analyze
+    --repoUrl=repourl.com
+
+    The number of days to consider
+    --days=30
+
+    The name of the branch to consider
+    --branch=main
+
+    The output format
+    --output=json
+
+    The location to save the results
+    --save=results
+`;

--- a/help.mjs
+++ b/help.mjs
@@ -17,6 +17,6 @@ Options:
     The output format
     --output=json
 
-    The location to save the results
-    --save=results
+    The location to save the results. Put "." to save in the current directory
+    --save=your-folder
 `;

--- a/help.mjs
+++ b/help.mjs
@@ -17,6 +17,7 @@ Options:
     The output format
     --output=json
 
-    The location to save the results. Put "." to save in the current directory
+    The location to save the result. Put "." to save in the current directory.
+    If the save argument is provided, the server will not start.
     --save=your-folder
 `;

--- a/index.mjs
+++ b/index.mjs
@@ -159,8 +159,11 @@ const server = http.createServer(function (req, res) {
   fs.readFile(resultsFilePath, function (err, data) {
     if (err) throw err;
 
-    if (output !== 'json' && output !== 'html') {
-      const errorMessage = '❌ Output format not supported (json or html)';
+    if (!cliArguments.output.choices.includes(output)) {
+      const errorMessage =
+        '❌ Output format not supported (' +
+        cliArguments.output.choices.join(' or ') +
+        ')';
       console.log(errorMessage);
       res.writeHead(500);
       res.write(errorMessage);

--- a/index.mjs
+++ b/index.mjs
@@ -8,9 +8,15 @@ import os from 'os';
 import net from 'net';
 import Enquirer from 'enquirer';
 import Parse from 'args-parser';
+import { help } from './help.mjs';
 const { prompt } = Enquirer;
 
 const args = Parse(process.argv);
+
+if (args.help) {
+  console.log(help);
+  process.exit(0);
+}
 
 let DEFAULT_PORT = 9666;
 let repoUrl = args.repoUrl;

--- a/index.mjs
+++ b/index.mjs
@@ -23,10 +23,15 @@ let repoUrl = args.repoUrl;
 let daysAmount = args.days || 30;
 let branchName = args.branch || 'main';
 let outputFormat = args.output || 'json';
-let saveLocation = args.save || 'results';
+let saveLocation = args.save || false;
 
 const tmpDir = path.join(os.tmpdir(), 'tmp-spyone');
-const resultsDir = path.join(os.tmpdir(), saveLocation);
+
+// if no save location is provided, save to tmp dir, otherwise save to the provided location starting from the current directory
+const resultsDir =
+  saveLocation === false
+    ? path.join(os.tmpdir(), 'results')
+    : path.join(process.cwd(), saveLocation);
 
 const params = [
   {
@@ -70,7 +75,7 @@ if (Object.keys(args).length === 0) {
 }
 
 if (!repoUrl) {
-  console.error('Usage: npx @jointly/spyone --repoUrl=repourl.com');
+  console.error(help);
   process.exit(1);
 }
 
@@ -129,6 +134,11 @@ const stats = [...data.entries()].reduce((prev, curr) => {
 }, 0);
 
 console.log(`Results saved to ${resultsFilePath}, total stats: ${stats}`);
+
+// exit here if save location is provided
+if (saveLocation !== false) {
+  process.exit(0);
+}
 
 const server = http.createServer(function (req, res) {
   fs.readFile(resultsFilePath, function (err, data) {

--- a/index.mjs
+++ b/index.mjs
@@ -25,6 +25,11 @@ let branchName = args.branch || 'main';
 let outputFormat = args.output || 'json';
 let saveLocation = args.save || false;
 
+// transform save argument from boolean to current directory if the user provide only --save
+if (saveLocation === true) {
+  saveLocation = '.';
+}
+
 const tmpDir = path.join(os.tmpdir(), 'tmp-spyone');
 
 // if no save location is provided, save to tmp dir, otherwise save to the provided location starting from the current directory

--- a/index.mjs
+++ b/index.mjs
@@ -159,7 +159,7 @@ const server = http.createServer(function (req, res) {
   fs.readFile(resultsFilePath, function (err, data) {
     if (err) throw err;
 
-    if (!cliArguments.output.choices.includes(output)) {
+    if (!isInteractive && !cliArguments.output.choices.includes(output)) {
       const errorMessage =
         '❌ Output format not supported (' +
         cliArguments.output.choices.join(' or ') +
@@ -169,7 +169,6 @@ const server = http.createServer(function (req, res) {
       res.write(errorMessage);
       res.end();
       process.exit(1);
-      return;
     }
 
     // build html page

--- a/index.mjs
+++ b/index.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import path from 'path';
 import fs from 'fs';
-import { downloadRepo, getData } from './utils.mjs';
+import { downloadRepo, getData, isValidRepoUrl } from './utils.mjs';
 import http from 'http';
 import { exec } from 'child_process';
 import os from 'os';
@@ -12,77 +12,87 @@ import { help } from './help.mjs';
 const { prompt } = Enquirer;
 
 const args = Parse(process.argv);
+const isInteractive = Object.keys(args).length === 0;
 
 if (args.help) {
   console.log(help);
   process.exit(0);
 }
 
+// Define possible arguments with his default values, both for interactive and cli mode
+const cliArguments = {
+  repoUrl: {
+    type: 'input',
+    default: '',
+    message: 'Enter the url of the repo to analyze',
+    required: true
+  },
+  days: {
+    type: 'input',
+    default: 30,
+    message: 'Enter the number of days to consider',
+    required: true
+  },
+  branch: {
+    type: 'input',
+    default: 'main',
+    message: 'Enter the name of the branch to consider',
+    required: true
+  },
+  output: {
+    type: 'select',
+    default: 'json',
+    message: 'Choose the output format',
+    choices: ['json', 'html'],
+    required: true
+  },
+  save: {
+    type: null,
+    default: false,
+    required: false
+  }
+};
+
 let DEFAULT_PORT = 9666;
-let repoUrl = args.repoUrl;
-let daysAmount = args.days || 30;
-let branchName = args.branch || 'main';
-let outputFormat = args.output || 'json';
-let saveLocation = args.save || false;
+
+// Transform to compatible format for enquirer
+const promptParams = Object.keys(cliArguments)
+  .filter((name) => cliArguments[name].type !== null)
+  .map((name) => {
+    return {
+      name,
+      ...cliArguments[name]
+    };
+  });
+
+// Destructure the arguments, if interactive mode is enabled, prompt the user for the values of the arguments, otherwise use the provided arguments. If no arguments are provided, use the default values
+const {
+  repoUrl = cliArguments.repoUrl.default,
+  days = cliArguments.days.default,
+  branch = cliArguments.branch.default,
+  output = cliArguments.output.default,
+  save = cliArguments.save.default
+} = isInteractive ? await prompt(promptParams) : args;
+
+// If no valid repo url is provided, exit with help
+if (!isValidRepoUrl(repoUrl)) {
+  console.error('❌ Invalid repo url');
+  console.error(help);
+  process.exit(1);
+}
 
 // transform save argument from boolean to current directory if the user provide only --save
-if (saveLocation === true) {
-  saveLocation = '.';
+if (save === true) {
+  save = '.';
 }
 
 const tmpDir = path.join(os.tmpdir(), 'tmp-spyone');
 
 // if no save location is provided, save to tmp dir, otherwise save to the provided location starting from the current directory
 const resultsDir =
-  saveLocation === false
+  save === false
     ? path.join(os.tmpdir(), 'results')
-    : path.join(process.cwd(), saveLocation);
-
-const params = [
-  {
-    type: 'input',
-    name: 'repoUrl',
-    message: 'Enter the url of the repo to analyze',
-    required: true
-  },
-  {
-    type: 'input',
-    name: 'daysAmount',
-    message: 'Enter the number of days to consider',
-    initial: 30,
-    required: true
-  },
-  {
-    type: 'input',
-    name: 'branchName',
-    message: 'Enter the name of the branch to consider',
-    initial: 'main',
-    required: true
-  },
-  {
-    type: 'select',
-    name: 'outputFormat',
-    message: 'Choose the output format',
-    choices: ['json', 'html'],
-    initial: 'json',
-    required: true
-  }
-];
-
-// Interactive mode if no args
-if (Object.keys(args).length === 0) {
-  const promptValues = await prompt(params);
-  // override params with prompt values
-  repoUrl = promptValues.repoUrl;
-  daysAmount = promptValues.daysAmount;
-  branchName = promptValues.branchName;
-  outputFormat = promptValues.outputFormat;
-}
-
-if (!repoUrl) {
-  console.error(help);
-  process.exit(1);
-}
+    : path.join(process.cwd(), save);
 
 // Drop folder if exists
 if (fs.existsSync(tmpDir)) {
@@ -94,11 +104,11 @@ fs.mkdirSync(tmpDir);
 
 // Download the repo
 console.log('Downloading repo...');
-await downloadRepo(repoUrl, tmpDir, branchName);
+await downloadRepo(repoUrl, tmpDir, branch);
 
 // Get the data
 console.log('Getting data...');
-let data = await getData(tmpDir, daysAmount);
+let data = await getData(tmpDir, days);
 
 // Sort data map by commitsCount, if equal sort by additions + deletions
 data = new Map(
@@ -122,7 +132,7 @@ const resultsFileName = `${today.getFullYear()}-${
 }-${today.getDate()}-${today.getHours()}-${today.getMinutes()}-${repoUrl
   .split('/')
   .pop()
-  .replace('.git', '')}-${daysAmount}-${branchName}.json`;
+  .replace('.git', '')}-${days}-${branch}.json`;
 const resultsFilePath = path.join(resultsDir, resultsFileName);
 const fileContent = JSON.stringify([...data.entries()]);
 fs.writeFileSync(resultsFilePath, fileContent);
@@ -141,7 +151,7 @@ const stats = [...data.entries()].reduce((prev, curr) => {
 console.log(`Results saved to ${resultsFilePath}, total stats: ${stats}`);
 
 // exit here if save location is provided
-if (saveLocation !== false) {
+if (save !== false) {
   process.exit(0);
 }
 
@@ -149,7 +159,7 @@ const server = http.createServer(function (req, res) {
   fs.readFile(resultsFilePath, function (err, data) {
     if (err) throw err;
 
-    if (outputFormat !== 'json' && outputFormat !== 'html') {
+    if (output !== 'json' && output !== 'html') {
       const errorMessage = '❌ Output format not supported (json or html)';
       console.log(errorMessage);
       res.writeHead(500);
@@ -160,7 +170,7 @@ const server = http.createServer(function (req, res) {
     }
 
     // build html page
-    if (outputFormat === 'html') {
+    if (output === 'html') {
       res.writeHead(200, { 'Content-Type': 'text/html' });
 
       fs.readFile('./index.html', null, function (error, html) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,90 +1,67 @@
 {
   "name": "@jointly/spyone",
   "version": "0.2.0",
-  "lockfileVersion": 3,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "@jointly/spyone",
-      "version": "0.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "net": "^1.0.2",
-        "simple-git": "^3.17.0"
-      },
-      "bin": {
-        "spyone": "index.mjs"
-      },
-      "devDependencies": {
-        "prettier": "^2.8.8"
-      }
-    },
-    "node_modules/@kwsites/file-exists": {
+  "dependencies": {
+    "@kwsites/file-exists": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
       "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
-      "dependencies": {
+      "requires": {
         "debug": "^4.1.1"
       }
     },
-    "node_modules/@kwsites/promise-deferred": {
+    "@kwsites/promise-deferred": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
-    "node_modules/debug": {
+    "ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
+    },
+    "args-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/args-parser/-/args-parser-1.3.0.tgz",
+      "integrity": "sha512-If3Zi4BSjlQIJ9fgAhSiKi0oJtgMzSqh0H4wvl7XSeO16FKx7QqaHld8lZeEajPX7y1C5qKKeNgyrfyvmjmjUQ=="
+    },
+    "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dependencies": {
+      "requires": {
         "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
-    "node_modules/ms": {
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
+    "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/net": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
-      "integrity": "sha512-kbhcj2SVVR4caaVnGLJKmlk2+f+oLkjqdKeQlmUtz6nGzOpbcobwVIeSURNgraV/v3tlmGIX82OcPCl0K6RbHQ=="
-    },
-    "node_modules/prettier": {
+    "prettier": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
+      "dev": true
     },
-    "node_modules/simple-git": {
+    "simple-git": {
       "version": "3.17.0",
       "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
       "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
-      "dependencies": {
+      "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
         "debug": "^4.3.4"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "prettier": "^2.8.8"
   },
   "dependencies": {
+    "args-parser": "^1.3.0",
+    "enquirer": "^2.3.6",
     "net": "^1.0.2",
     "simple-git": "^3.17.0"
   }

--- a/utils.mjs
+++ b/utils.mjs
@@ -27,6 +27,14 @@ export const downloadRepo = (repoUrl, dir, branchName = 'main') => {
   });
 };
 
+// Check if the repo url is valid and well formatted
+export const isValidRepoUrl = (repoUrl) => {
+  const regex = new RegExp(
+    '^https:\\/\\/github.com\\/[a-zA-Z0-9-]+\\/[a-zA-Z0-9-]+$'
+  );
+  return regex.test(repoUrl);
+};
+
 // Given a path to a directory, get the list of addition and deletion counts from the git history of each file
 export const getData = (dir, daysAmount) => {
   return new Promise(async (resolve, reject) => {


### PR DESCRIPTION
This PR add the following features:

- Users can run the command without args and get in interactive mode. They got prompted all required fields to execute spyone.
- --save flag let the user to execute the tool in CI context, or automation scripts in custom flows. This features let the user to save the file without prompt nothing and without starting the server. In this case we except that the command will be launched from a machine.
- Standardized help

The code refactor clarify the flow of the args thanks to the new args-parser library.
We are able to execute the tool in both flows, interactive mode and automated task, and the variables will be overriden to the specific flow.

I also added a new help.mjs file, this file help us to write a standalone help text that will be showed in case the user launch
the --help, -help, or just help.

This help get showed to the user also in case they type an unexpected options.

Feedback and suggestions are also appreciated.