### PR TITLE
feat: automatic release made via Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          makeLatest: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR provides an automatic Github Release whenever we push a tag.  
I think this would be a painless and useful addition.

@buggyzap you are not a contributor so I can't ask for a formal review, but surely I'd appreciate your feedback on this regard.